### PR TITLE
Fix configuration variable name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ listener setup, the `openid` listener can be added on the same port as the `clie
 listener.
 
 Room membership is still currently limited to be verified from a single
-configured homeserver client API via `UVS_HOMESERVER_CLIENT_API_URL`.
+configured homeserver client API via `UVS_HOMESERVER_URL`.
 
 ### API's available
 


### PR DESCRIPTION
I couldn't find `UVS_HOMESERVER_CLIENT_API_URL` anywhere beside README.md, so I guess it's meant to be `UVS_HOMESERVER_URL`.